### PR TITLE
Implement =all function (Fixes #5)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,16 @@ Returns a number with the product of arguments:
    >>> dicteval({"=mul": [3, 5]})
    15
 
+Function ``=all``
+'''''''''''''''''
+
+Return True if all elements of the iterable are true (or if the iterable is empty)
+
+   >>> dicteval({"=mul": (True, False)})
+   False
+   >>> dicteval({"=mul": (True, True)})
+   True
+
 To Do
 -----
 

--- a/dicteval/__init__.py
+++ b/dicteval/__init__.py
@@ -35,6 +35,9 @@ class BuiltinLanguage(LanguageSpecification):
     def function_mul(self, value, evaluator, context):
         return functools.reduce(operator.mul, (evaluator(v, context) for v in value))
 
+    def function_all(self, value, evaluator, context):
+        return all(evaluator(v, context) for v in value)
+
 
 class Evaluator:
     def __init__(self, language_spec):

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -17,6 +17,9 @@ from dicteval.exceptions import FunctionNotFound
     ({"=sum": (3, 5)}, 8),
     ({"=sum": {"=": [3, 5]}}, 8),
     ({"=mul": (5, 3, 2, -1)}, -30),
+    ({"=all": (True, True, True)}, True),
+    ({"=all": (True, False, True)}, False),
+    ({"=all": (False, False, False)}, False),
 ])
 def test_basic_eval(expression, result):
     assert dicteval(expression) == result
@@ -45,6 +48,9 @@ def test_json_loads():
     ("not", False, True),
     ("sum", (1, 2), 3),
     ("mul", (2, 4), 8),
+    ("all", tuple(), True),
+    ("all", (True, True), True),
+    ("all", (True, False), False),
 ])
 def test_buitin_language(fn, args, result, context):
     language = BuiltinLanguage()


### PR DESCRIPTION
This adds `=all` that behaves like Python's builtin `all`. 