### PR TITLE
implement reduce, with optional start value

### DIFF
--- a/dicteval/__init__.py
+++ b/dicteval/__init__.py
@@ -96,7 +96,7 @@ class Evaluator:
             if func.__name__ in ['function_map',
                                  'function_filter',
                                  'function_reduce']:
-                hof, coll_func = re.search(r'(map|filter|reduce)\((.*)\)',key).groups()#[1]
+                hof, coll_func = re.search(r'(map|filter|reduce)\((.*)\)',key).groups()
                 if hof == 'reduce':
                     coll_func, *start = re.split(r',\s*?start\s*?=',coll_func)
                     return func(eval(coll_func), value, self, context,start=start)

--- a/dicteval/__init__.py
+++ b/dicteval/__init__.py
@@ -3,7 +3,7 @@ import json
 import operator
 import re
 
-# from .exceptions import FunctionNotFound
+from .exceptions import FunctionNotFound
 
 
 class LanguageSpecification:

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -23,6 +23,8 @@ from dicteval.exceptions import FunctionNotFound
     ({"=all": (True, False, True)}, False),
     ({"=all": (False, False, False)}, False),
     ({"=zip": ([1, 2, 3], [4, 5], [6, 7, 8, 9])}, [(1, 4, 6), (2, 5, 7)]),
+    ({'=reduce(lambda x,y: x + y)':[2,3,4,5]}, 14),
+    ({'=reduce(lambda x,y: x + y, start=100)':[2,3,4,5]}, 114)
 ])
 def test_basic_eval(expression, result):
     assert dicteval(expression) == result


### PR DESCRIPTION
Had a go at implementing reduce.  

It would be easy to handle without an optional starting accumulator, but in the spirit of fully replicating the built-in version I decided to build that functionality out.  There is quite a bit of overhead for having that convenience though (in the form of additional if branching , duplicated calling logic in function_reduce etc.), so I'll leave it to @osantana to decide what's best.  

This can be simplified if we do not care about the optional accumulator, but the issue requested full replication so that's what I've done.

